### PR TITLE
Support thank you message line breaks

### DIFF
--- a/templates/donor-donation-success.html.twig
+++ b/templates/donor-donation-success.html.twig
@@ -26,7 +26,7 @@
 
   {% if campaignThankYouMessage %}
     <p>A message from {{ charityName }}:</p>
-    <blockquote>{{ campaignThankYouMessage }}</blockquote>
+    <blockquote>{{ campaignThankYouMessage | nl2br }}</blockquote>
   {% endif %}
 
   <p>If you have any questions, please contact us.</p>


### PR DESCRIPTION
Charities have a multi-line field for this custom message, so to reflect the new line formatting they would expect we should convert breaks to HTML new lines.