### PR TITLE
MAIL-15 - remove last names from emails

### DIFF
--- a/templates/donor-donation-success.html.twig
+++ b/templates/donor-donation-success.html.twig
@@ -1,7 +1,7 @@
 {% extends renderHtml ? '_base.html.twig' : '_base.text.twig' %}
 
 {% block content %}
-  <p>Dear {{ donorFirstName }} {{ donorLastName }},</p>
+  <p>Dear {{ donorFirstName }},</p>
 
   <p>Thank you for supporting {{ charityName }} with your generous gift through the Big Give.<p>
 

--- a/templates/pledger-success.html.twig
+++ b/templates/pledger-success.html.twig
@@ -1,7 +1,7 @@
 {% extends renderHtml ? '_base.html.twig' : '_base.text.twig' %}
 
 {% block content %}
-  <p>Dear {{ pledgerFirstName }} {{ pledgerLastName }},</p>
+  <p>Dear {{ pledgerFirstName }},</p>
 
   <p>Thank you for your generous match funding pledge of {{ pledgeAmount | format_currency('GBP') }} to {{ charityName }} for the campaign: {{ campaignName }}. You will be asked to fulfill your pledge promise after the campaign closes on {{ campaignEndDate }}, and by {{ campaignPledgeSubmissionDeadline }}.</p>
 


### PR DESCRIPTION
This is primarily to reduce the data leak 'blast radius' if a donor or pledger accidentally makes
a typo and gives somebody else's valid email address. To keep the change low risk and make it easy
to revert if necessary, for now I am leaving the `*lastName` fields as required input for these
emails, since it is already sent and never blank. Mailer does not persist this data, which
is only transferred encrypted, so I think in this case it's OK to continue passing it to the app.