### PR TITLE
MAIL-40 - show date with timezone abbreviation (e.g. GMT), not timezone identifier

### DIFF
--- a/templates/donor-donation-success.html.twig
+++ b/templates/donor-donation-success.html.twig
@@ -29,7 +29,7 @@
   </p>
 
   <ul>
-    <li>Donation date: <strong>{{ donationDatetime | date('j F Y, H:i e', 'Europe/London') }}</strong></li>
+    <li>Donation date: <strong>{{ donationDatetime | date('j F Y, H:i T', 'Europe/London') }}</strong></li>
     <li>Donor: <strong>{{ donorFirstName }} {{ donorLastName }}</strong></li>
     <li>Total for {{ charityName }}: <strong>{{ totalCharityValueAmount | format_currency(currencyCode) }}</strong></li>
     <li>Donation: <strong>{{ donationAmount | format_currency(currencyCode) }}</strong></li>


### PR DESCRIPTION
See https://www.php.net/manual/en/datetime.format.php