### PR TITLE
MAIL-38 – fix ECS DI compile crash

### DIFF
--- a/app/dependencies.php
+++ b/app/dependencies.php
@@ -15,6 +15,7 @@ use Monolog\Processor\UidProcessor;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
@@ -101,7 +102,7 @@ return function (ContainerBuilder $containerBuilder) {
             // Timeout comes from php.ini's `default_socket_timeout` – 8 seconds in our Docker base.
             // See https://symfony.com/doc/current/mailer.html#using-a-3rd-party-transport
             $transport = (new EsmtpTransportFactory())->create(
-                $c->get('settings')['mailer']['dsn'],
+                Dsn::fromString($c->get('settings')['mailer']['dsn']),
             );
             return new Symfony\Component\Mailer\Mailer($transport);
         },

--- a/app/settings.php
+++ b/app/settings.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use DI\ContainerBuilder;
 use Mailer\Application\ConfigModels\Email;
 use Monolog\Logger;
-use Symfony\Component\Mailer\Transport\Dsn;
 
 return function (ContainerBuilder $containerBuilder) {
     // Global Settings Object
@@ -92,7 +91,7 @@ return function (ContainerBuilder $containerBuilder) {
             'mailer' => [
                 // Used for various transport configuration by Symfony Mailer.
                 // See https://symfony.com/doc/current/mailer.html#using-built-in-transports
-                'dsn' => Dsn::fromString(getenv('MAILER_DSN')),
+                'dsn' => getenv('MAILER_DSN'),
             ],
 
             'twig' => [


### PR DESCRIPTION
Prod-like mode DI was broken at compile time, with full DSN object as part
of the return value, with "An object was found but objects cannot be compiled"