### PR TITLE
MAIL-47: Bugfix - Remove obsolete required param on donor-funds-thanks

### DIFF
--- a/app/settings.php
+++ b/app/settings.php
@@ -88,7 +88,6 @@ return function (ContainerBuilder $containerBuilder) {
                     'requiredParams' => [
                         'donorFirstName',
                         'transferAmount',
-                        'newBalance',
                     ],
                 ],
                 [


### PR DESCRIPTION
This was the only remaining mention of newBalance in mailer