### PR TITLE
MAIL-53: Include hash of recipient email address in logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ MAILER_DSN=smtp://smtp:25
 
 MESSENGER_TRANSPORT_DSN=redis://redis:6379/messenger
 SEND_SECRET=myLocalSendSecret
-
+LOG_PEPPER=myLocalLogPepper
 SENDER_ADDRESS=hello@biggive.org


### PR DESCRIPTION
Not tested but very simple, should be fine to test in staging after merge. Needs a matching PR in infrastructure to pass the new pepper to mailer. Ideally the infrastructure PR should be merged to prod first, but think the risk is small if this one goes out first.