### PR TITLE
DON-1009: Add template for regular giving mandate confirmation email

### DIFF
--- a/templates/donor-mandate-confirmation.html.twig
+++ b/templates/donor-mandate-confirmation.html.twig
@@ -1,0 +1,68 @@
+{% extends renderHtml ? '_base.html.twig' : '_base.text.twig' %}
+
+{% block content %}
+    <h1>Regular Giving Mandate for {{ charityName }}</h1>
+
+    <p>
+    Thank you for supporting {{ charityName }} with your generous gift through Big Give.
+    </p>
+
+    <p>
+    A message from {{ charityName }}:
+    </p>
+    <blockquote>{{ campaignThankYouMessage | nl2br }}</blockquote>
+
+    <p>
+        {{ campaignThankYouEmail }}
+    </p>
+
+    <h2>Regular Giving Mandate Details</h2>
+    <p>
+        Thank you for setting up your regular gift to {{ charityName }} for the {{ campaignName }} campaign. {{ charityName }}
+        is registered with the Charity Commission for England and Wales with charity number {{ charityNumber }}. This email
+        certifies that no goods or services will be provided in return for your contribution.
+    </p>
+
+    <ul>
+        <li>Regular gift sign up date: {{ signupDate}}</li>
+        <li>Donor: {{ donorName }}</li>
+        <li>Schedule: {{ schedule }}</li>
+        <li>Next expected payment date: {{ nextPaymentDate }}</li>
+        <li>Amount: {{ amount }}</li>
+        <li>Gift aid value: {{ giftAidValue }}</li>
+        <li>Total with gift aid: {{totalIncGiftAid }}</li>
+    </ul>
+    <p>Total amount you have been charged is {{ totalCharged }}</p>
+
+    <h2>First donation details</h2>
+
+    <ul>
+        <li>First donation: {{firstDonation.donationAmount | format_currency(firstDonation.currencyCode) }}</li>
+        <li>Donation date: {{firstDonation.donationDatetime | date('j F Y, H:i T', 'Europe/London') }}</li>
+        <li>Gift aid value: {{firstDonation.giftAidAmountClaimed | format_currency(firstDonation.currencyCode) }}</li>
+        <li>Total with gift aid: {{firstDonation.totalWithGiftAid | format_currency(firstDonation.currencyCode) }}</li>
+        <li>Matched amount: {{firstDonation.matchedAmount | format_currency(firstDonation.currencyCode) }}</li>
+        <li>Total for {{ firstDonation.charityName }}: {{ firstDonation.totalCharityValueAmount | format_currency(firstDonation.currencyCode) }}</li>
+        <li>Donation reference: {{ firstDonation.transactionId }}</li>
+        <li>Reference on credit/debit card statement: {{ firstDonation.statementReference }}</li>
+    </ul>
+
+    <h2>{{charityName}}</h2>
+
+    <ul>
+        <li>
+            <p>{{ charityName }}</p>
+            <p>{{ charityPostalAddress }}</p>
+        </li>
+        {% if charityPhoneNumber is not empty %}
+            <li>Tel: {{ charityPhoneNumber }}</li>
+        {% endif %}
+        {% if charityEmailAddress is not empty %}
+            <li>Email: {{ charityEmailAddress }}</li>
+        {% endif %}
+        {% if charityWebsite is not empty %}
+            <li>Web: <a href="{{ charityWebsite }}">{{ charityWebsite }}</a></li>
+        {% endif %}
+    </ul>
+
+{% endblock %}

--- a/tests/templates/RegularGivingConfirmationTest.php
+++ b/tests/templates/RegularGivingConfirmationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Mailer\Tests\templates;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class RegularGivingConfirmationTest extends TestCase
+{
+    use MatchesSnapshots;
+
+    public function testItRenders(): void
+    {
+        $rendered = Renderer::renderMessage(
+            'donor-mandate-confirmation.html.twig',
+            [
+                'charityName' => '[Charity Name]',
+                'campaignName' => '[Campaign Name]',
+                'charityNumber' => '[Charity Number]',
+                'campaignThankYouMessage' => '[Campaign Thank You Message]',
+                'campaignThankYouEmail' => 'campaign@thankyou.email',
+
+                'signupDate' => 'DD/MM/YYYY HH:MM',
+                'donorName' => '[Donor Name]',
+                'schedule' => 'Monthly on day #3',
+                'nextPaymentDate' => 'MM/DD/YYYY',
+                'amount' => '£20.00',
+                'giftAidValue' => '£4.00',
+                'totalIncGiftAid' => '£24.00',
+                'totalCharged' => '£20.00',
+                'charityPostalAddress' => '[Charity Postal Address]',
+                'charityPhoneNumber' => '[Charity Phone Number]',
+                'charityEMailAddress' => '[Charity E-Mail Address]',
+                'charityWebsite' => 'https://charity.website',
+
+                'firstDonation' => [
+                    // mostly same keys as used on the donorDonationSuccess email
+                    'donationDatetime' => new \DateTimeImmutable('2023-01-30'),
+                    'currencyCode' => 'GBP',
+                    'charityName' => '[Charity Name]',
+                    'donationAmount' => 25_000,
+                    'giftAidAmountClaimed' => 1_000,
+                    'totalWithGiftAid' => 26_000,
+                    'matchedAmount' => 25_000,
+                    'totalCharityValueAmount' => 50_000,
+                    'transactionId' => '[PSP Transaction ID]',
+                    'statementReference' => 'The Big Give [Charity Name]'
+                ],
+            ]
+        );
+
+        $this->assertMatchesSnapshot($rendered);
+    }
+}

--- a/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt
+++ b/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt
@@ -1,0 +1,65 @@
+    <h1>Regular Giving Mandate for [Charity Name]</h1>
+
+    <p>
+    Thank you for supporting [Charity Name] with your generous gift through Big Give.
+    </p>
+
+    <p>
+    A message from [Charity Name]:
+    </p>
+    <blockquote>[Campaign Thank You Message]</blockquote>
+
+    <p>
+        campaign@thankyou.email
+    </p>
+
+    <h2>Regular Giving Mandate Details</h2>
+    <p>
+        Thank you for setting up your regular gift to [Charity Name] for the [Campaign Name] campaign. [Charity Name]
+        is registered with the Charity Commission for England and Wales with charity number [Charity Number]. This email
+        certifies that no goods or services will be provided in return for your contribution.
+    </p>
+
+    <ul>
+        <li>Regular gift sign up date: DD/MM/YYYY HH:MM</li>
+        <li>Donor: [Donor Name]</li>
+        <li>Schedule: Monthly on day #3</li>
+        <li>Next expected payment date: MM/DD/YYYY</li>
+        <li>Amount: £20.00</li>
+        <li>Gift aid value: £4.00</li>
+        <li>Total with gift aid: £24.00</li>
+    </ul>
+    <p>Total amount you have been charged is £20.00</p>
+
+    <h2>First donation details</h2>
+
+    <ul>
+        <li>First donation: £25,000.00</li>
+        <li>Donation date: 30 January 2023, 00:00 GMT</li>
+        <li>Gift aid value: £1,000.00</li>
+        <li>Total with gift aid: £26,000.00</li>
+        <li>Matched amount: £25,000.00</li>
+        <li>Total for [Charity Name]: £50,000.00</li>
+        <li>Donation reference: [PSP Transaction ID]</li>
+        <li>Reference on credit/debit card statement: The Big Give [Charity Name]</li>
+    </ul>
+
+    <h2>[Charity Name]</h2>
+
+    <ul>
+        <li>
+            <p>[Charity Name]</p>
+            <p>[Charity Postal Address]</p>
+        </li>
+                    <li>Tel: [Charity Phone Number]</li>
+                                    <li>Web: <a href="https://charity.website">https://charity.website</a></li>
+            </ul>
+
+    Kind regards,
+    Big Give Team
+
+    Big Give, Dragon Court, 27-29 Macklin Street, London, WC2B 5LX
+    Email: hello@biggive.org   Web: https://biggive.org
+    The Big Give Trust (charity number: 1136547; company number: 07273065)
+
+    Your card details are held securely by Stripe. We do not have access to your card details.

--- a/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt.html
+++ b/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt.html
@@ -1,0 +1,65 @@
+    <h1>Regular Giving Mandate for [Charity Name]</h1>
+
+    <p>
+    Thank you for supporting [Charity Name] with your generous gift through Big Give.
+    </p>
+
+    <p>
+    A message from [Charity Name]:
+    </p>
+    <blockquote>[Campaign Thank You Message]</blockquote>
+
+    <p>
+        campaign@thankyou.email
+    </p>
+
+    <h2>Regular Giving Mandate Details</h2>
+    <p>
+        Thank you for setting up your regular gift to [Charity Name] for the [Campaign Name] campaign. [Charity Name]
+        is registered with the Charity Commission for England and Wales with charity number [Charity Number]. This email
+        certifies that no goods or services will be provided in return for your contribution.
+    </p>
+
+    <ul>
+        <li>Regular gift sign up date: DD/MM/YYYY HH:MM</li>
+        <li>Donor: [Donor Name]</li>
+        <li>Schedule: Monthly on day #3</li>
+        <li>Next expected payment date: MM/DD/YYYY</li>
+        <li>Amount: £20.00</li>
+        <li>Gift aid value: £4.00</li>
+        <li>Total with gift aid: £24.00</li>
+    </ul>
+    <p>Total amount you have been charged is £#.##</p>
+
+    <h2>First donation details</h2>
+
+    <ul>
+        <li>First donation: £25,000.00</li>
+        <li>Donation date: 30 January 2023, 00:00 GMT</li>
+        <li>Gift aid value: £1,000.00</li>
+        <li>Total with gift aid: £26,000.00</li>
+        <li>Matched amount: £25,000.00</li>
+        <li>Total for [Charity Name]: £50,000.00</li>
+        <li>Donation reference: [PSP Transaction ID]</li>
+        <li>Reference on credit/debit card statement: The Big Give [Charity Name]</li>
+    </ul>
+
+    <h2>[Charity Name]</h2>
+
+    <ul>
+        <li>
+            <p>[Charity Name]</p>
+            <p>[Charity Postal Address]</p>
+        </li>
+                    <li>Tel: [Charity Phone Number]</li>
+                                    <li>Web: <a href="https://charity.website">https://charity.website</a></li>
+            </ul>
+
+    Kind regards,
+    Big Give Team
+
+    Big Give, Dragon Court, 27-29 Macklin Street, London, WC2B 5LX
+    Email: hello@biggive.org   Web: https://biggive.org
+    The Big Give Trust (charity number: 1136547; company number: 07273065)
+
+    Your card details are held securely by Stripe. We do not have access to your card details.


### PR DESCRIPTION
The template is based on @DomTBG 's work on Jira. I've added inline comments where I've deviated and to query some bits.

The implementation style is slightly incoherent - I started off assuming all the variables are display-ready strings, but then for the section of the email where we show the details of the first donation I thought it would make sense to mirror the data structure used for the existing donation confirmation email, and that takes e.g. money amounts as numbers, timestamps as objects and does formatting within mailer. Probably worth going one way or the other, but that might depend whether we end up calling this from salesforce or from matchbot. I feel like formatting is probably easier to do in matchbot so if its called from matchbot it makes more sense to take all fields as pre-formatted strings.

When reviewing its probably also worth comparing with what we have in [donor-donation-success.html.twig](https://github.com/thebiggive/mailer/blob/unfreeze-trunk/templates/donor-donation-success.html.twig). There might be stuff there that we also need here, e.g. probably the "is an exempt charitable organisation eligible for UK Gift Aid". We could also share template code between the two emails if we want to make sure that they say the same thing and can't accidentally diverge in future.