### PR TITLE
DON-1009: Remove charity details from regular giving confirmation

### DIFF
--- a/templates/donor-mandate-confirmation.html.twig
+++ b/templates/donor-mandate-confirmation.html.twig
@@ -12,10 +12,6 @@
     </p>
     <blockquote>{{ campaignThankYouMessage | nl2br }}</blockquote>
 
-    <p>
-        {{ campaignThankYouEmail }}
-    </p>
-
     <h2>Regular Giving Mandate Details</h2>
     <p>
         Thank you for setting up your regular gift to {{ charityName }} for the {{ campaignName }} campaign. {{ charityName }}
@@ -48,21 +44,4 @@
     </ul>
 
     <h2>{{charityName}}</h2>
-
-    <ul>
-        <li>
-            <p>{{ charityName }}</p>
-            <p>{{ charityPostalAddress }}</p>
-        </li>
-        {% if charityPhoneNumber is not empty %}
-            <li>Tel: {{ charityPhoneNumber }}</li>
-        {% endif %}
-        {% if charityEmailAddress is not empty %}
-            <li>Email: {{ charityEmailAddress }}</li>
-        {% endif %}
-        {% if charityWebsite is not empty %}
-            <li>Web: <a href="{{ charityWebsite }}">{{ charityWebsite }}</a></li>
-        {% endif %}
-    </ul>
-
 {% endblock %}

--- a/templates/donor-mandate-confirmation.html.twig
+++ b/templates/donor-mandate-confirmation.html.twig
@@ -42,6 +42,4 @@
         <li>Donation reference: {{ firstDonation.transactionId }}</li>
         <li>Reference on credit/debit card statement: {{ firstDonation.statementReference }}</li>
     </ul>
-
-    <h2>{{charityName}}</h2>
 {% endblock %}

--- a/tests/templates/RegularGivingConfirmationTest.php
+++ b/tests/templates/RegularGivingConfirmationTest.php
@@ -18,7 +18,6 @@ class RegularGivingConfirmationTest extends TestCase
                 'campaignName' => '[Campaign Name]',
                 'charityNumber' => '[Charity Number]',
                 'campaignThankYouMessage' => '[Campaign Thank You Message]',
-                'campaignThankYouEmail' => 'campaign@thankyou.email',
 
                 'signupDate' => 'DD/MM/YYYY HH:MM',
                 'donorName' => '[Donor Name]',
@@ -28,10 +27,6 @@ class RegularGivingConfirmationTest extends TestCase
                 'giftAidValue' => '£4.00',
                 'totalIncGiftAid' => '£24.00',
                 'totalCharged' => '£20.00',
-                'charityPostalAddress' => '[Charity Postal Address]',
-                'charityPhoneNumber' => '[Charity Phone Number]',
-                'charityEMailAddress' => '[Charity E-Mail Address]',
-                'charityWebsite' => 'https://charity.website',
 
                 'firstDonation' => [
                     // mostly same keys as used on the donorDonationSuccess email

--- a/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt
+++ b/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt
@@ -39,8 +39,6 @@
         <li>Donation reference: [PSP Transaction ID]</li>
         <li>Reference on credit/debit card statement: The Big Give [Charity Name]</li>
     </ul>
-
-    <h2>[Charity Name]</h2>
     Kind regards,
     Big Give Team
 

--- a/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt
+++ b/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt
@@ -9,10 +9,6 @@
     </p>
     <blockquote>[Campaign Thank You Message]</blockquote>
 
-    <p>
-        campaign@thankyou.email
-    </p>
-
     <h2>Regular Giving Mandate Details</h2>
     <p>
         Thank you for setting up your regular gift to [Charity Name] for the [Campaign Name] campaign. [Charity Name]
@@ -45,16 +41,6 @@
     </ul>
 
     <h2>[Charity Name]</h2>
-
-    <ul>
-        <li>
-            <p>[Charity Name]</p>
-            <p>[Charity Postal Address]</p>
-        </li>
-                    <li>Tel: [Charity Phone Number]</li>
-                                    <li>Web: <a href="https://charity.website">https://charity.website</a></li>
-            </ul>
-
     Kind regards,
     Big Give Team
 


### PR DESCRIPTION
These emails are going to be sent from matchbot which does not currently hold these details