### PR TITLE
DON-1009: Share twig code between donation thanks mesage and regular …

### DIFF
--- a/templates/donation-details-partial.html.twig
+++ b/templates/donation-details-partial.html.twig
@@ -1,0 +1,10 @@
+    <li>Donation date: <strong>{{ donationDatetime | date('j F Y, H:i T', 'Europe/London') }}</strong></li>
+    <li>Donor: <strong>{{ donorName }}</strong></li>
+    <li>Total for {{ charityName }}: <strong>{{ totalCharityValueAmount | format_currency(currencyCode) }}</strong></li>
+    <li>Donation: <strong>{{ donationAmount | format_currency(currencyCode) }}</strong></li>
+    {% if currencyCode is same as('GBP') %}
+        <li>Gift Aid: <strong>{{ giftAidAmountClaimed | format_currency(currencyCode) }}</strong></li>
+    {% endif %}
+    {% if matchedAmount > 0 %}
+        <li>Match Funds: <strong>{{ matchedAmount | format_currency(currencyCode) }}</strong></li>
+    {% endif %}

--- a/templates/donor-donation-success.html.twig
+++ b/templates/donor-donation-success.html.twig
@@ -29,16 +29,16 @@
   </p>
 
   <ul>
-    <li>Donation date: <strong>{{ donationDatetime | date('j F Y, H:i T', 'Europe/London') }}</strong></li>
-    <li>Donor: <strong>{{ donorFirstName }} {{ donorLastName }}</strong></li>
-    <li>Total for {{ charityName }}: <strong>{{ totalCharityValueAmount | format_currency(currencyCode) }}</strong></li>
-    <li>Donation: <strong>{{ donationAmount | format_currency(currencyCode) }}</strong></li>
-    {% if currencyCode is same as('GBP') %}
-      <li>Gift Aid: <strong>{{ giftAidAmountClaimed | format_currency(currencyCode) }}</strong></li>
-    {% endif %}
-    {% if matchedAmount > 0 %}
-        <li>Match Funds: <strong>{{ matchedAmount | format_currency(currencyCode) }}</strong></li>
-    {% endif %}
+    {% include 'donation-details-partial.html.twig' with {
+      'donationAmount': donationAmount,
+      'donationDatetime': donationDatetime,
+      'donorName': donorFirstName ~ ' ' ~ donorLastName,
+      'charityName': charityName,
+      'totalCharityValueAmount': totalCharityValueAmount,
+      'currencyCode': currencyCode,
+      'giftAidAmountClaimed': giftAidAmountClaimed,
+      'matchedAmount': matchedAmount,
+    } only %}
   </ul>
 
   <p>

--- a/templates/donor-mandate-confirmation.html.twig
+++ b/templates/donor-mandate-confirmation.html.twig
@@ -33,12 +33,16 @@
     <h2>First donation details</h2>
 
     <ul>
-        <li>First donation: {{firstDonation.donationAmount | format_currency(firstDonation.currencyCode) }}</li>
-        <li>Donation date: {{firstDonation.donationDatetime | date('j F Y, H:i T', 'Europe/London') }}</li>
-        <li>Gift aid value: {{firstDonation.giftAidAmountClaimed | format_currency(firstDonation.currencyCode) }}</li>
-        <li>Total with gift aid: {{firstDonation.totalWithGiftAid | format_currency(firstDonation.currencyCode) }}</li>
-        <li>Matched amount: {{firstDonation.matchedAmount | format_currency(firstDonation.currencyCode) }}</li>
-        <li>Total for {{ firstDonation.charityName }}: {{ firstDonation.totalCharityValueAmount | format_currency(firstDonation.currencyCode) }}</li>
+        {% include 'donation-details-partial.html.twig' with {
+            'donationAmount': firstDonation.donationAmount,
+            'donationDatetime': firstDonation.donationDatetime,
+            'donorName': donorName,
+            'charityName': charityName,
+            'totalCharityValueAmount': firstDonation.totalCharityValueAmount,
+            'currencyCode': firstDonation.currencyCode,
+            'giftAidAmountClaimed': firstDonation.giftAidAmountClaimed,
+            'matchedAmount': firstDonation.matchedAmount,
+        } only %}
         <li>Donation reference: {{ firstDonation.transactionId }}</li>
         <li>Reference on credit/debit card statement: {{ firstDonation.statementReference }}</li>
     </ul>

--- a/tests/templates/__snapshots__/DonorDonationSuccessTest__testSendRendersForDonationFunds__1.txt
+++ b/tests/templates/__snapshots__/DonorDonationSuccessTest__testSendRendersForDonationFunds__1.txt
@@ -15,11 +15,11 @@
   </p>
 
   <ul>
-    <li>Donation date: <strong>30 January 2023, 00:00 GMT</strong></li>
+        <li>Donation date: <strong>30 January 2023, 00:00 GMT</strong></li>
     <li>Donor: <strong>Joe Bloggs</strong></li>
     <li>Total for CHARITY: <strong>£50,000.00</strong></li>
     <li>Donation: <strong>£25,000.00</strong></li>
-          <li>Gift Aid: <strong>£1,000.00</strong></li>
+            <li>Gift Aid: <strong>£1,000.00</strong></li>
                 <li>Match Funds: <strong>£25,000.00</strong></li>
       </ul>
 

--- a/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt
+++ b/tests/templates/__snapshots__/RegularGivingConfirmationTest__testItRenders__1.txt
@@ -30,13 +30,13 @@
     <h2>First donation details</h2>
 
     <ul>
-        <li>First donation: £25,000.00</li>
-        <li>Donation date: 30 January 2023, 00:00 GMT</li>
-        <li>Gift aid value: £1,000.00</li>
-        <li>Total with gift aid: £26,000.00</li>
-        <li>Matched amount: £25,000.00</li>
-        <li>Total for [Charity Name]: £50,000.00</li>
-        <li>Donation reference: [PSP Transaction ID]</li>
+            <li>Donation date: <strong>30 January 2023, 00:00 GMT</strong></li>
+    <li>Donor: <strong>[Donor Name]</strong></li>
+    <li>Total for [Charity Name]: <strong>£50,000.00</strong></li>
+    <li>Donation: <strong>£25,000.00</strong></li>
+            <li>Gift Aid: <strong>£1,000.00</strong></li>
+                <li>Match Funds: <strong>£25,000.00</strong></li>
+            <li>Donation reference: [PSP Transaction ID]</li>
         <li>Reference on credit/debit card statement: The Big Give [Charity Name]</li>
     </ul>
     Kind regards,


### PR DESCRIPTION
…giving confirmation message

This does change the way we show the first donation in the regular giving message slightly. As far as I know the differences between that and the ad-hoc donation message were not planned.

Probably most useful to review changes in the test snapshots.

'only' keyword stops twig auto-including all variables from the outer template into the scope of the inner one, making the code more verbose but more self-documenting.

I think this PR is enough to get the ticket ready for QA.