### PR TITLE
INFRA-142 – give every `SendRequest` its own message group

### DIFF
--- a/src/Application/HttpModels/SendRequest.php
+++ b/src/Application/HttpModels/SendRequest.php
@@ -61,7 +61,8 @@ class SendRequest implements MessageGroupAwareInterface
         $this->env = getenv('APP_ENV');
     }
 
-    public function getMessageGroupId(): ?string
+    #[\Override]
+    public function getMessageGroupId(): string
     {
         return "send-request-{$this->id}";
     }

--- a/src/Application/HttpModels/SendRequest.php
+++ b/src/Application/HttpModels/SendRequest.php
@@ -6,9 +6,10 @@ namespace Mailer\Application\HttpModels;
 
 use OpenApi\Attributes as OA;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\MessageGroupAwareInterface;
 
 #[OA\Schema(type: 'object', title: 'Send Request', required: ['templateKey', 'recipientEmailAddress', 'params'])]
-class SendRequest
+class SendRequest implements MessageGroupAwareInterface
 {
     #[OA\Property(example: "donor-donation-success")]
     public string $templateKey;
@@ -58,5 +59,10 @@ class SendRequest
     {
         $this->id = (Uuid::uuid4())->toString();
         $this->env = getenv('APP_ENV');
+    }
+
+    public function getMessageGroupId(): ?string
+    {
+        return "send-request-{$this->id}";
     }
 }


### PR DESCRIPTION
This should allow us to use FIFO queues in high throughput mode without any message blocking others. (We want to stick with FIFO to ensure at-most-once delivery but we don't actually care about delivery order.)