### PR TITLE
Add details to error logs

### DIFF
--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -74,10 +74,13 @@ class HttpErrorHandler extends SlimErrorHandler
         $response = $this->responseFactory->createResponse($statusCode);
         $response->getBody()->write($encodedPayload);
 
+        $uri = $_SERVER['REQUEST_URI'] ?? '';
+        $remoteAddr = $_SERVER['REMOTE_ADDR'] ?? '';
+
         $this->logError(
             get_class($this->exception) .
             ": {$this->exception->getMessage()} - {$this->exception->getTraceAsString()} " .
-            "- Request URI: {$_SERVER['REQUEST_URI']} - Remote Addr: {$_SERVER['REMOTE_ADDR']}"
+            "- Request URI: {$uri} - Remote Addr: {$remoteAddr}"
         );
 
         return $response->withHeader('Content-Type', 'application/json');

--- a/src/Application/Handlers/HttpErrorHandler.php
+++ b/src/Application/Handlers/HttpErrorHandler.php
@@ -75,7 +75,9 @@ class HttpErrorHandler extends SlimErrorHandler
         $response->getBody()->write($encodedPayload);
 
         $this->logError(
-            get_class($this->exception) . ": {$this->exception->getMessage()} - {$this->exception->getTraceAsString()}"
+            get_class($this->exception) .
+            ": {$this->exception->getMessage()} - {$this->exception->getTraceAsString()} " .
+            "- Request URI: {$_SERVER['REQUEST_URI']} - Remote Addr: {$_SERVER['REMOTE_ADDR']}"
         );
 
         return $response->withHeader('Content-Type', 'application/json');


### PR DESCRIPTION
We seem to be getting more HttpNotFoundException logs than I would expect for an internal service. Adding extra detail to logs to try to find out why