### PR TITLE
Make charity thank you message optional in donation and mandate thank…

### DIFF
--- a/app/settings.php
+++ b/app/settings.php
@@ -26,7 +26,6 @@ return function (ContainerBuilder $containerBuilder) {
                     'subjectParams' => ['donorFirstName'],
                     'requiredParams' => [
                         'campaignName',
-                        'campaignThankYouMessage',
                         'charityName',
                         'currencyCode',
                         'donationAmount',

--- a/templates/donor-mandate-confirmation.html.twig
+++ b/templates/donor-mandate-confirmation.html.twig
@@ -7,10 +7,12 @@
     Thank you for supporting {{ charityName }} with your generous gift through Big Give.
     </p>
 
+{% if campaignThankYouMessage %}
     <p>
     A message from {{ charityName }}:
     </p>
     <blockquote>{{ campaignThankYouMessage | nl2br }}</blockquote>
+{% endif %}
 
     <h2>Regular Giving Mandate Details</h2>
     <p>


### PR DESCRIPTION
… you messages

Generally a charity should always have a custom thanks message set on their campaign, but in any cases that this is missing we don't want to block their donors getting an email to confirm their action.