### PR TITLE
Make custom thank you message optional in mandate confirmation email

### DIFF
--- a/app/settings.php
+++ b/app/settings.php
@@ -95,7 +95,6 @@ return function (ContainerBuilder $containerBuilder) {
                     'requiredParams' => [
                         'charityName',
                         'campaignName',
-                        'campaignThankYouMessage',
                         'signupDate',
                         'donorName',
                         'schedule',


### PR DESCRIPTION
I thought I had done this already in commit 21fa483fa6 but that only made it optional for ad-hoc donations, this makes it optional for regular giving.

Just had an alarm on staging because this field is null for a campaign there.