### PR TITLE
ID-47: Remove duplicate closing in email

### DIFF
--- a/templates/new-account-email-already-registered.html.twig
+++ b/templates/new-account-email-already-registered.html.twig
@@ -14,8 +14,4 @@
         If you didn’t make this request, you can ignore this email. If you need any more help setting up or logging in
         to your Big Give account, <a href="https://biggive.org/support/">check out our FAQs or contact us</a>.
     </p>
-
-    <p>Thanks,</p>
-
-    <p>Big Give team</p>
 {% endblock %}


### PR DESCRIPTION
Base template already says "Kind Regards, Big Give Team", we don't need to duplicate the message here.