### PR TITLE
Fix Symfony 8 message consumer startup crash

### DIFF
--- a/src/Application/Console.php
+++ b/src/Application/Console.php
@@ -21,11 +21,11 @@ final class Console extends Application
         private LoggerInterface $logger,
         private TransportInterface $transport
     ) {
+        parent::__construct();
+
         $this->addCommands([
             $this->getConsumeCommand(),
         ]);
-
-        parent::__construct();
     }
 
     private function getConsumeCommand(): ConsumeMessagesCommand


### PR DESCRIPTION
Got e.g.
`PHP Fatal error:  Uncaught Error: Typed property Symfony\Component\Console\Application::$container must not be accessed before initialization in /var/www/html/vendor/symfony/console/Application.php:1387`